### PR TITLE
Smathot inline javascript

### DIFF
--- a/src/js/osweb/classes/javascript_workspace.js
+++ b/src/js/osweb/classes/javascript_workspace.js
@@ -3,12 +3,11 @@
  * not persistent, and only exposes the vars object.
  */
 export default class JavaScriptWorkspace {
-
   /**
      * Create a JavaScript workspace.
      * @param {Object} experiment - The experiment item to which the item belongs.
      */
-  constructor(experiment) {
+  constructor (experiment) {
     this.experiment = experiment
   }
 
@@ -16,7 +15,7 @@ export default class JavaScriptWorkspace {
      * Executes JavaScript code in the workspace.
      * @param {String} js - JavaScript code to execute
      */
-  _eval(js) {
+  _eval (js) {
     let vars = this.experiment.vars
     eval(js)
   }

--- a/src/js/osweb/classes/var_store.js
+++ b/src/js/osweb/classes/var_store.js
@@ -21,24 +21,25 @@ class VarStore {
    */
   get (variable, defaultValue, evaluate, valid) {
     // Gets an experimental variable.
+    let value = defaultValue || null
     if (this.has(variable)) {
       if (typeof this[variable] === 'string') {
-        return this._item.syntax.eval_text(this[variable], null, true)
+        value = this._item.syntax.eval_text(this[variable], null, true)
       } else {
-        return this[variable]
+        value = this[variable]
       }
     }
     // If value is not found locally, look in experiment object.
-    if (this._parent && this._parent.has(variable)) {
+    if (value === null && this._parent && this._parent.has(variable)) {
       if (typeof this._parent[variable] === 'string') {
-        return this._item.syntax.eval_text(this._parent[variable], null, true)
+        value = this._item.syntax.eval_text(this._parent[variable], null, true)
       } else {
-        return this._parent[variable]
+        value = this._parent[variable]
       }
     }
 
     // Return function result.
-    return defaultValue || null
+    return value
   }
 
   /**
@@ -105,10 +106,9 @@ const varStoreHandler = {
   construct (Target, args) {
     return new Proxy(new Target(...args), {
       get (target, prop) {
-        return (['_item', '_parent'].includes(prop) ||
-          typeof target[prop] === 'function')
-          ? target[prop]
-          : target.get(prop)
+        return typeof target[prop] === 'string'
+          ? target.get(prop)
+          : target[prop]
       }
     })
   }

--- a/src/js/osweb/items/coroutines.js
+++ b/src/js/osweb/items/coroutines.js
@@ -1,0 +1,22 @@
+import Item from './item.js'
+
+/**
+ * Class representing coroutines
+ * @extends Item
+ */
+export default class Coroutines extends Item {
+  constructor (experiment, name, script) {
+    // Inherited create.
+    super(experiment, name, script)
+    // Definition of public properties.
+    this.description = 'Repeatedly runs another item'
+    // Process the script.
+    this.from_string(script)
+
+    this.coroutines = []
+  }
+
+  from_string (script) {
+
+  }
+}

--- a/src/js/osweb/items/inline_javascript.js
+++ b/src/js/osweb/items/inline_javascript.js
@@ -19,14 +19,13 @@ export default class InlineJavaScript extends Item {
     this.description = 'Executes JavaScript code (ECMA 5.1)'
     this.workspace = new JavaScriptWorkspace(this.experiment)
     // Process the script
-    console.log(this.vars)
     this.from_string(script)
   }
 
   /** Reset all item variables to their default value. */
   reset () {
-    this.vars._prepare = ''
-    this.vars._run = ''
+    this._prepare = ''
+    this._run = ''
   }
 
   /**
@@ -60,16 +59,16 @@ export default class InlineJavaScript extends Item {
               break
             default:
               if (read_run_lines === true) {
-                this.vars._run = this.vars._run + lines[i] + '\n'
+                this._run = this._run + lines[i] + '\n'
               } else if (read_prepare_lines === true) {
-                this.vars._prepare = this.vars._prepare + lines[i] + '\n'
+                this._prepare = this._prepare + lines[i] + '\n'
               }
           }
         } else {
           if (read_run_lines === true) {
-            this.vars._run = this.vars._run + lines[i] + '\n'
+            this._run = this._run + lines[i] + '\n'
           } else if (read_prepare_lines === true) {
-            this.vars._prepare = this.vars._prepare + lines[i] + '\n'
+            this._prepare = this._prepare + lines[i] + '\n'
           }
         }
       }
@@ -78,7 +77,7 @@ export default class InlineJavaScript extends Item {
 
   /** Implements the prepare phase of an item. */
   prepare () {
-    this.workspace._eval(this.vars._prepare)
+    this.workspace._eval(this._prepare)
     super.prepare()
   }
 
@@ -86,7 +85,7 @@ export default class InlineJavaScript extends Item {
   run () {
     super.run()
     this.set_item_onset()
-    this.workspace._eval(this.vars._run)
+    this.workspace._eval(this._run)
     this._complete()
   }
 }


### PR DESCRIPTION
My additions of a proxied var_store (and coroutines class that accidentally slipped through).
I needed to change the inline_javascript class too, because the this.vars._prepare contents also were evaluated, and these tripped parser that is configured for osweb script. I don't think you'll want to store the inline js in the vars object, so I simply made _prepare and _run class properties. This works well for me, but can you give it a spin too?