### PR TITLE
Fix parsing of values with numbers in scientific notation

### DIFF
--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -239,8 +239,7 @@ export default class Syntax {
     for (var i = 0; i < tokens.length; i++) {
       var value = tokens[i]
       // Monster regex, splits into key/value pair.
-      var parsed = value.split(/(?:("[^"\\]*(?:\\.[^"\\]*)*"))|(?:(\w+)=(?:(?:(-?\d*\.{0,1}\d+)|(\w+))|("[^"\\]*(?:\\.[^"\\]*)*")))/gm).filter(Boolean)
-
+      let parsed = value.split(/(?:("[^"\\]*(?:\\.[^"\\]*)*"))|(?:(\w+)=(?:(?:(-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)|(\w+))|("[^"\\]*(?:\\.[^"\\]*)*")))/gm).filter(Boolean)
       // parsed will have length 1 if the variable has no keyword, and will be
       // of length 2 (split over the = symbol) if the variable had a keyword
       if (parsed.length < 2) {

--- a/src/js/tests/classes/syntax.test.js
+++ b/src/js/tests/classes/syntax.test.js
@@ -110,6 +110,10 @@ describe('Syntax', function () {
         'test': '"quoted"'
       })
     })
+    it('should be able to parse numbers in scientific notation', function () {
+      checkCmd('test test=-9e-9',
+        'test', [], {"test": -9e-9})
+    })    
     it("should throw an exception when string can't be parsed", function () {
       expect(function () {
         checkCmd('widget 0 0 1 1 label text="Tést 123',


### PR DESCRIPTION
Key-value pairs such as `x=-9e-09` were misinterpreted, as described in #8. I changed the regular expression that catches numbers to fix this, and also implemented a unit test.