### PR TITLE
Fixes #18: Parsing of variables in loop ops

### DIFF
--- a/src/js/osweb/items/loop.js
+++ b/src/js/osweb/items/loop.js
@@ -72,7 +72,7 @@ export default class Loop extends Item {
       if (isArray(el)) {
         return this._eval_args(el)
       } else {
-        return this._runner._syntax.eval_text(el)
+        return this._runner._syntax.remove_quotes(this._runner._syntax.eval_text(el))
       }
     })
   }


### PR DESCRIPTION
Variables were correctly resolved, but the problem was that they were doubly quotes. So the parsing function got `""[var]""` and made this into `""3""`. I did an extra call for to `syntax.removeQuotes()` with the resolved variable, which solves the problem for the test cases  I ran and didn't break anything. Still, we should see where this addition of the extra quotes occurs, and maybe see if we can make this whole process a bit cleaner.