### PR TITLE
Fix numbers on sketchpads

### DIFF
--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -895,7 +895,7 @@ export default class Canvas {
   text (txt, center, x, y, html, styleArgs) {
     // Newlines are not dealt with correctly, so we convert them to <br />
     // tags, which results in the same behavior as the desktop.
-    txt = txt.replace('\n', '<br />')
+    txt = txt.toString().replace('\n', '<br />')
     // Get the style
     const elementStyle = this._getStyle(styleArgs)
 


### PR DESCRIPTION
Text consisting of only a number caused a crash, as described in #40 and #44. This seems to be sufficient to fix it.