### PR TITLE
Various bugfixes and cleanup of sketchpad/ response functionality

### DIFF
--- a/src/js/osweb/backends/keyboard.js
+++ b/src/js/osweb/backends/keyboard.js
@@ -17,7 +17,7 @@ export default class Keyboard {
     this._timeOut = (typeof timeOut === 'undefined') ? null : timeOut // Duration in millisecond for time-out.
 
     // Set constant properties.
-    this._SYNONIEM_MAP = [
+    this._SYNONYM_MAP = [
       ['space', ' ', 'SPACE'],
       ['"', 'quotedbl', 'QUOTEDBL'],
       ['!', 'exclaim', 'EXCLAIM'],
@@ -157,11 +157,11 @@ export default class Keyboard {
   }
 
   /**
-   * Convert all response values to their default values (remove synoniems).
+   * Convert all response values to their default values (remove synonyms).
    * @param {Array} responses - A list of response values.
    * @return {Array} - List of default values for the given responses.
    */
-  _get_default_from_synoniem (responses) {
+  _get_default_from_synonym (responses) {
     const defaults = []
     let synonyms
     for (let i = 0; i < responses.length; i++) {
@@ -186,16 +186,16 @@ export default class Keyboard {
   }
 
   /**
-   * Convert a response value to its default value (remove synoniem).
+   * Convert a response value to its default value (remove synonym).
    * @param {String} button - A response.
    * @return {String|Null} - Default value of the response.
    */
   _synonyms (button) {
     if (typeof button !== 'undefined') {
-      for (let i = 0; i < this._SYNONIEM_MAP.length; i++) {
-        for (let j = 0; j < this._SYNONIEM_MAP[i].length; j++) {
-          if (this._SYNONIEM_MAP[i][j] === button) {
-            return this._SYNONIEM_MAP[i]
+      for (let i = 0; i < this._SYNONYM_MAP.length; i++) {
+        for (let j = 0; j < this._SYNONYM_MAP[i].length; j++) {
+          if (this._SYNONYM_MAP[i][j] === button) {
+            return this._SYNONYM_MAP[i]
           }
         }
       }

--- a/src/js/osweb/backends/mouse.js
+++ b/src/js/osweb/backends/mouse.js
@@ -19,7 +19,7 @@ export default class Mouse {
     this._visible = (typeof visible === 'undefined') ? false : visible
 
     // Set constant properties.
-    this._SYNONIEM_MAP = [
+    this._SYNONYM_MAP = [
       ['1', 'left_button'],
       ['2', 'middle_button'],
       ['3', 'right_button'],
@@ -29,16 +29,16 @@ export default class Mouse {
   }
 
   /**
-   * Convert all response values to their default values (remove synoniems).
+   * Convert all response values to their default values (remove synonyms).
    * @param {Array} responses - A list of response values.
    * @return {Array} - List of default values for the given responses.
    */
-  _get_default_from_synoniem (responses) {
-    // Return the default synoniem value from a response.
+  _get_default_from_synonym (responses) {
+    // Return the default synonym value from a response.
     var defaults = []
     for (var i = 0; i < responses.length; i++) {
-      var synoniem = this._synonyms(responses[i])
-      defaults.push(synoniem[0])
+      var synonym = this._synonyms(responses[i])
+      defaults.push(synonym[0])
     }
     return defaults
   }
@@ -57,16 +57,16 @@ export default class Mouse {
   }
 
   /**
-   * Convert a response value to its default value (remove synoniem).
+   * Convert a response value to its default value (remove synonym).
    * @param {String} button - A response.
    * @return {String|Null} - Default value of the response or null if none.
    */
   _synonyms (button) {
     if (typeof button !== 'undefined') {
-      for (var i = 0; i < this._SYNONIEM_MAP.length; i++) {
-        for (var j = 0; j < this._SYNONIEM_MAP[i].length; j++) {
-          if (this._SYNONIEM_MAP[i][j] === button) {
-            return this._SYNONIEM_MAP[i]
+      for (var i = 0; i < this._SYNONYM_MAP.length; i++) {
+        for (var j = 0; j < this._SYNONYM_MAP[i].length; j++) {
+          if (this._SYNONYM_MAP[i][j] === button) {
+            return this._SYNONYM_MAP[i]
           }
         }
       }

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -61,12 +61,6 @@ export default class GenericResponse extends Item {
     }
   }
 
-  /** The auto responder method for simulated keyboard interaction. */
-  auto_responser () {}
-
-  /** The auto responder method for simulated mouse interaction. */
-  auto_responser_mouse () {}
-
   /** Prepare the list with allowed responses */
   prepare_allowed_responses () {
     // Prepare the allowed responses.

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -25,7 +25,6 @@ export default class GenericResponse extends Item {
     this._timeout = -1
 
     // Create and set public properties.
-    this.auto_response = 'a'
     this.process_feedback = false
     this.synonyms = null
   }
@@ -127,24 +126,16 @@ export default class GenericResponse extends Item {
   prepare_duration_keypress () {
     // Prepare a keyboard duration.
     this._keyboard = new Keyboard(this.experiment)
-    if (this.experiment.auto_response === true) {
-      this._duration_func = this.auto_responder
-    } else {
-      var final_duration = (this._timeout !== -1) ? this._timeout : this._duration
-      this._keyboard._set_config(final_duration, this._allowed_responses)
-    }
+    var final_duration = (this._timeout !== -1) ? this._timeout : this._duration
+    this._keyboard._set_config(final_duration, this._allowed_responses)
   }
 
   /** Prepare the system for a mouseclick duration interval. */
   prepare_duration_mouseclick () {
     // Prepare a mouseclick duration.
     this._mouse = new Mouse(this.experiment)
-    if (this.experiment.auto_response === true) {
-      this._duration_func = this.auto_responder_mouse
-    } else {
-      var final_duration = (this._timeout !== -1) ? this._timeout : this._duration
-      this._mouse._set_config(final_duration, this._allowed_responses, false)
-    }
+    var final_duration = (this._timeout !== -1) ? this._timeout : this._duration
+    this._mouse._set_config(final_duration, this._allowed_responses, false)
   }
 
   /** Prepare the system for a timeout. */

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -75,10 +75,10 @@ export default class GenericResponse extends Item {
           : item).filter(Boolean)
       if (this.vars.duration === 'keypress') {
         // this._allowed_responses = allowed_responses;
-        this._allowed_responses = this._keyboard._get_default_from_synoniem(allowed_responses)
+        this._allowed_responses = this._keyboard._get_default_from_synonym(allowed_responses)
       } else if (this.vars.duration === 'mouseclick') {
         // For mouse responses, we don't check if the allowed responses make sense.
-        this._allowed_responses = this._mouse._get_default_from_synoniem(allowed_responses)
+        this._allowed_responses = this._mouse._get_default_from_synonym(allowed_responses)
       }
 
       // If allowed responses are provided, the list should not be empty.

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -278,9 +278,8 @@ export default class GenericResponse extends Item {
   prepare () {
     // Implements the prepare phase of the item.
     this.prepare_timeout()
-    this.prepare_allowed_responses()
     this.prepare_duration()
-
+    this.prepare_allowed_responses()
     // Inherited.
     super.prepare()
   }

--- a/src/js/osweb/items/keyboard_response.js
+++ b/src/js/osweb/items/keyboard_response.js
@@ -69,7 +69,7 @@ export default class KeyboardResponse extends GenericResponse {
       const keypress = this.experiment._runner._events._processKeyboardEvent(event, 1)
       let allowed_responses = 'all'
       if (this.vars.get('allowed_responses')) {
-        allowed_responses = this._keyboard._get_default_from_synoniem(
+        allowed_responses = this._keyboard._get_default_from_synonym(
           this.vars.get('allowed_responses').split(';').map(key => key.trim())
         )
       }

--- a/src/js/osweb/items/keyboard_response.js
+++ b/src/js/osweb/items/keyboard_response.js
@@ -29,7 +29,6 @@ export default class KeyboardResponse extends GenericResponse {
 
   /** Resets all item variables to their default value. */
   reset () {
-    this.auto_response = 'space'
     this.process_feedback = true
     this.vars.allowed_responses = null
     this.vars.correct_response = null

--- a/src/js/osweb/items/keyboard_response.js
+++ b/src/js/osweb/items/keyboard_response.js
@@ -13,17 +13,10 @@ export default class KeyboardResponse extends GenericResponse {
      * @param {String} script - The script containing the properties of the item.
      */
   constructor (experiment, name, script) {
-    // Inherited.
     super(experiment, name, script)
-
-    // Definition of public properties.
     this.description = 'Collects keyboard responses'
-
-    // Definition of private properties.
     this._flush = 'yes'
     this._keyboard = new Keyboard(this.experiment)
-
-    // Process the script.
     this.from_string(script)
   }
 

--- a/src/js/osweb/items/mouse_response.js
+++ b/src/js/osweb/items/mouse_response.js
@@ -39,7 +39,6 @@ export default class MouseResponse extends GenericResponse {
 
   /** Resets all item variables to their default value. */
   reset () {
-    this.auto_response = 1
     this.process_feedback = true
     this.resp_codes = {}
     this.resp_codes['0'] = 'timeout'

--- a/src/js/osweb/items/mouse_response.js
+++ b/src/js/osweb/items/mouse_response.js
@@ -13,18 +13,10 @@ export default class MouseResponse extends GenericResponse {
      * @param {String} script - The script containing the properties of the item.
      */
   constructor (experiment, name, script) {
-    // Inherited.
     super(experiment, name, script)
-
-    // Definition of public properties.
     this.description = 'Collects mouse responses'
     this.resp_codes = {}
-
-    // Definition of private properties.
     this._flush = 'yes'
-    this._mouse = new Mouse(this.experiment)
-
-    // Process the script.
     this.from_string(script)
   }
 

--- a/src/js/osweb/items/sketchpad.js
+++ b/src/js/osweb/items/sketchpad.js
@@ -40,6 +40,11 @@ export default class Sketchpad extends GenericResponse {
     this.elements = []
     this.vars.duration = 'keypress'
   }
+  
+  /** Process a time out response. */
+  process_response_timeout () {
+    // Nothing happens
+  }
 
   /**
      * Parse a definition string and retrieve all properties of the item.


### PR DESCRIPTION
A `sketchpad` should not interfere with response variables when a numeric duration is specified. Overriding `process_response_timeout()` seems to fix this. See also #38.

Another fix relates to the order in which things are prepared by `generic_response`, thus fixing #28.

Finally a bit of code cleanup to change Dutch spelling (synoniem) to English (synonym) and remove unused dummy code.