### PR TITLE
Fix memory leak when showing images

### DIFF
--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -369,6 +369,11 @@ export default class Canvas {
     for (var i = this._container.children.length - 1; i >= 0; i--) {
       this._container.removeChild(this._container.children[i])
     }
+    let texture
+    while (this._textures.length > 0) {
+      texture = this._textures.pop()
+      texture.destroy(true)
+    }
   }
 
   /**
@@ -881,13 +886,7 @@ export default class Canvas {
       console.error(e)
     }
     this.experiment._runner._renderer.render(this._container)
-    const showTime = (experiment != null ? experiment.clock.time() : null)
-    let texture
-    while (this._textures.length > 0) {
-      texture = this._textures.pop()
-      texture.destroy(true)
-    }
-    return showTime
+    return (experiment != null ? experiment.clock.time() : null)
   }
 
   /**

--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -20,6 +20,7 @@ export default class Canvas {
     this._height = this.experiment._runner._renderer.height // Height of the HTML canvas used for drawing.
     this._styles = new Styles() // The style container.
     this._width = this.experiment._runner._renderer.width // Width of the HTML canvas used for drawing.
+    this._textures = []
   }
 
   /**
@@ -570,7 +571,9 @@ export default class Canvas {
     ctx.putImageData(px, 0, 0)
 
     // Retrieve the image from the recourses
-    var sprite = new Sprite(Texture.from(canvas))
+    const texture = Texture.from(canvas)
+    this._textures.push(texture)
+    var sprite = new Sprite(texture)
 
     // Position the image.
     sprite.x = x - (size / 2)
@@ -619,7 +622,9 @@ export default class Canvas {
     const ctx = canvas.getContext('2d')
     ctx.drawImage(img, 0, 0)
 
-    const sprite = new Sprite(Texture.from(canvas))
+    const texture = Texture.from(canvas)
+    this._textures.push(texture)
+    const sprite = new Sprite(texture)
 
     // Scale the image.
     sprite.scale.x = scale
@@ -766,7 +771,9 @@ export default class Canvas {
     ctx.putImageData(px, 0, 0)
 
     // Retrieve the image from the recourses
-    var sprite = new Sprite(Texture.from(canvas))
+    const texture = Texture.from(canvas)
+    this._textures.push(texture)
+    var sprite = new Sprite(texture)
 
     // Position the image.
     sprite.x = x - (size / 2)
@@ -874,13 +881,13 @@ export default class Canvas {
       console.error(e)
     }
     this.experiment._runner._renderer.render(this._container)
-
-    // Return the current time.
-    if (experiment != null) {
-      return experiment.clock.time()
-    } else {
-      return null
+    const showTime = (experiment != null ? experiment.clock.time() : null)
+    let texture
+    while (this._textures.length > 0) {
+      texture = this._textures.pop()
+      texture.destroy(true)
     }
+    return showTime
   }
 
   /**


### PR DESCRIPTION
In PixiJS, it appears that `Texture` objects need to be explicitly destroyed. Garbage collection doesn't take care of this. This didn't happen currently, and as a result experiments with many images keep eating up data until they crash. This PR keeps track of all textures that are created and then destroys them after showing the `Canvas`. This seems to do the trick.

This is a pretty bad issue, so if this fix indeed addresses it, then I would like to release this as 1.3.11 and include it with OpenSesame 3.3.6.

See also:

- https://forum.cogsci.nl/discussion/6697/ram-overload-when-running-in-osweb