### PR TITLE
Correctly parse unquoted non-ascii words

### DIFF
--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -278,6 +278,14 @@ export default class Syntax {
       var value = tokens[i]
       // Monster regex, splits into key/value pair.
       let parsed = value.split(/(?:("[^"\\]*(?:\\.[^"\\]*)*"))|(?:(\w+)=(?:(?:(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)|(\w+))|("[^"\\]*(?:\\.[^"\\]*)*")))/gm).filter(Boolean)
+      // This is a horrifying hack to deal with the fact that the regular
+      // expression above is not unicode-safe. This means that a single
+      // unquoted word is not seen as a word when it doesn't consist of ascii
+      // characters (e.g. text=λάθος). See also:
+      // - https://github.com/open-cogsci/osweb/issues/49
+      if (parsed.length === 1 && parsed[0].startsWith('text=')) {
+        parsed = ['text', parsed[0].slice(5)]
+      }
       // parsed will have length 1 if the variable has no keyword, and will be
       // of length 2 (split over the = symbol) if the variable had a keyword
       if (parsed.length < 2) {

--- a/src/js/tests/classes/syntax.test.js
+++ b/src/js/tests/classes/syntax.test.js
@@ -62,15 +62,20 @@ describe('Syntax', function () {
   })
 
   describe('parse_cmd()', function () {
-    var checkCmd = function (s, cmd, arglist, kwdict) {
+    var checkCmd = function (s, cmd, arglist, kwdict, create_expect) {
       // parse command into arguments
       let _cmd, _arglist, _kwdict;
       [_cmd, _arglist, _kwdict] = syntax.parse_cmd(s)
       expect(_cmd).toBe(cmd)
       expect(_arglist).toEqual(arglist)
       expect(_kwdict).toEqual(kwdict)
-      // translate arguments back to command
-      expect(s).toBe(syntax.create_cmd(_cmd, _arglist, _kwdict))
+      // translate arguments back to command. Some commands may recreate back
+      // to a slightly different string than the input string, in which case
+      // we specify an explicit create_expect target.
+      if (typeof create_expect === 'undefined') {
+        create_expect = s
+      }
+      expect(create_expect).toBe(syntax.create_cmd(_cmd, _arglist, _kwdict))
     }
 
     it('should parse command with arguments and keyword arguments', function () {
@@ -78,6 +83,12 @@ describe('Syntax', function () {
         'widget', [0, 0, 1, 1, 'label'], {
           text: 'Tést 123'
         })
+    })
+    it('should parse command with unquoted non-latin words', function() {
+        checkCmd('draw textline text=λάθος',
+            'draw', ['textline'], {text: 'λάθος'},
+            'draw textline text="λάθος"'
+        )
     })
     it('should parse a single command with no arguments', function () {
       checkCmd('test', 'test', [], {})


### PR DESCRIPTION
Should fix #49 