### PR TITLE
Fix loops with only a single cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osweb",
-	"version": "1.3.12",
+	"version": "1.3.13",
 	"main": "src/js/osweb/index.js",
 	"description": "Online runtime for OpenSesame experiments",
 	"license": "GPL-3.0",

--- a/src/js/osweb/items/loop.js
+++ b/src/js/osweb/items/loop.js
@@ -218,6 +218,7 @@ export default class Loop extends Item {
   /** Implements the run phase of an item. */
   run () {
     super.run()
+    debugger
     if (!this._initialized) {
       // The first step is to create an array of cycle indices (`cycles`). We
       // first add the integer part of the repeats to this array, which results
@@ -258,7 +259,7 @@ export default class Loop extends Item {
       // is why this._cycles is only determined afterwards.
       this.matrix = this._operations.reduce((mtrx, [func, args]) =>
         func(mtrx, ...this._eval_args(args)), this.matrix)      
-      this._cycles = Array(... this.matrix.keys())
+      this._cycles = [... this.matrix.keys()]
       this._initialized = true
       this._index = null
     } // end init


### PR DESCRIPTION
A serious bug has been introduced in OSWeb 1.3.12, namely that `loop`s with only a single cycle are skipped. The reason for this is that the following are not synonymous, as I thought they were:

```
Array(... some_iterable)
```

And

```
[... some_iterable]
```

When some_iterable has more than 1 element, then both are the same. However, with only a single element, the result for the first is an empty array, whereas for the second it is an array with only a single element. See the screenshot below.

![image](https://user-images.githubusercontent.com/594936/107239812-83100280-6a29-11eb-9c61-9cd127627526.png)

This is a pretty serious bug, so I think it warrants release of 1.3.13.
